### PR TITLE
Fix typo + add phi input for Electron SF  + MeasureTaggingEff 

### DIFF
--- a/AnalyzerTools/include/MyCorrection.h
+++ b/AnalyzerTools/include/MyCorrection.h
@@ -135,19 +135,19 @@ public:
     float GetCTaggingR(const float npvs, const float HT, const JetTagging::JetFlavTagger tagger, const TString &processName = "", const TString &ttBarCategory = "total", const TString &syst_str = "") const;
     inline float GetCTaggingSF(const RVec<Jet> &jets, const JetTagging::JetTaggingSFMethod &method = JetTagging::JetTaggingSFMethod::mujets, const variation syst = variation::nom, const TString &source = "total") { return GetCTaggingSF(jets, global_tagger, global_wp, method, syst, source); }
     // electron
-    float GetElectronRECOSF(const float abseta, const float pt, const variation syst = variation::nom, const TString &source = "total") const;
-    float GetElectronIDSF(const TString &Electron_ID_SF_Key, const float abseta, const float pt, const variation syst = variation::nom, const TString &source = "total") const;
-    float GetElectronTriggerEff(const TString &Electron_ID_SF_Key, const float eta, const float pt, bool ofDATA, const variation syst = variation::nom, const TString &source = "total") const;
-    inline float GetElectronTriggerDataEff(const TString &Electron_ID_SF_Key, const float eta, const float pt, const variation syst = variation::nom, const TString &source = "total")
+    float GetElectronRECOSF(const float abseta, const float pt, const float phi, const variation syst = variation::nom, const TString &source = "total") const;
+    float GetElectronIDSF(const TString &Electron_ID_SF_Key, const float abseta, const float pt, const float phi, const variation syst = variation::nom, const TString &source = "total") const;
+    float GetElectronTriggerEff(const TString &Electron_ID_SF_Key, const float eta, const float pt, const float phi, bool ofDATA, const variation syst = variation::nom, const TString &source = "total") const;
+    inline float GetElectronTriggerDataEff(const TString &Electron_ID_SF_Key, const float eta, const float pt, const float phi, const variation syst = variation::nom, const TString &source = "total")
     {
-        return GetElectronTriggerEff(Electron_ID_SF_Key, eta, pt, true, syst, source);
+        return GetElectronTriggerEff(Electron_ID_SF_Key, eta, pt, phi, true, syst, source);
     };
-    inline float GetElectronTriggerMCEff(const TString &Electron_ID_SF_Key, const float eta, const float pt, const variation syst = variation::nom, const TString &source = "total")
+    inline float GetElectronTriggerMCEff(const TString &Electron_ID_SF_Key, const float eta, const float pt, const float phi, const variation syst = variation::nom, const TString &source = "total")
     {
-        return GetElectronTriggerEff(Electron_ID_SF_Key, eta, pt, false, syst, source);
+        return GetElectronTriggerEff(Electron_ID_SF_Key, eta, pt, phi, false, syst, source);
     };
 
-    float GetElectronTriggerSF(const TString &Electron_Trigger_SF_Key, const float eta, const float pt, const variation syst = variation::nom, const TString &source = "total") const;
+    float GetElectronTriggerSF(const TString &Electron_Trigger_SF_Key, const float eta, const float pt, const float phi, const variation syst = variation::nom, const TString &source = "total") const;
     float GetElectronIDSF(const TString &Electron_ID_SF_Key, const RVec<Electron> &electrons, const variation syst = variation::nom, const TString &source = "total") const;
     float GetElectronRECOSF(const RVec<Electron> &electrons, const variation syst = variation::nom, const TString &source = "total") const;
     // photon

--- a/AnalyzerTools/include/MyCorrection.h
+++ b/AnalyzerTools/include/MyCorrection.h
@@ -67,6 +67,17 @@ public:
             }
         }
     }
+
+    inline bool isInputInCorrection(const std::string &key, const correction::Correction::Ref &cset) const
+    {
+        std::vector<std::string> inputs;
+        for (const auto &input : cset->inputs())
+        {
+            inputs.push_back(input.name());
+        }
+        return std::find(inputs.begin(), inputs.end(), key) != inputs.end();
+    }
+
     MyCorrection();
     MyCorrection(const TString &era, const TString &sample, const bool IsData, const string &btagging_eff_file = "btaggingEff.json", const string &ctagging_eff_file = "ctaggingEff.json", const string &btagging_R_file = "btaggingR.json", const string &ctagging_R_file = "ctaggingR.json");
     ~MyCorrection();

--- a/AnalyzerTools/include/SystematicHelper.h
+++ b/AnalyzerTools/include/SystematicHelper.h
@@ -42,7 +42,7 @@ public:
         std::string iter_name;
         std::string syst_name;
         std::string syst_source;
-        Correction::variation variation;
+        MyCorrection::variation variation;
     };
 
 
@@ -51,7 +51,7 @@ public:
         std::string iter_name;
         std::string syst_name;
         std::string syst_source;
-        Correction::variation variation;
+        MyCorrection::variation variation;
         void clone(Iter_obj &obj)
         {
             iter_name = obj.iter_name;
@@ -116,7 +116,7 @@ public:
     inline std::string getCurrentSysName() const { return current_Iter_obj.iter_name; }
     inline std::string getCurrentIterSysTarget() const { return current_Iter_obj.syst_name; }
     inline std::string getCurrentIterSysSource() const { return current_Iter_obj.syst_source; }
-    inline Correction::variation getCurrentIterVariation() const { return current_Iter_obj.variation; }
+    inline MyCorrection::variation getCurrentIterVariation() const { return current_Iter_obj.variation; }
 
     std::vector<std::string> get_targets_from_name(const std::string &syst_name);
     std::vector<std::string> get_sources_from_name(const std::string &syst_name);

--- a/AnalyzerTools/include/SystematicHelper.h
+++ b/AnalyzerTools/include/SystematicHelper.h
@@ -41,12 +41,8 @@ public:
     {
         std::string iter_name;
         std::string syst_name;
-<<<<<<< HEAD
-        MyCorrection::variation variation;
-=======
         std::string syst_source;
         Correction::variation variation;
->>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
     };
 
 
@@ -54,12 +50,8 @@ public:
     {
         std::string iter_name;
         std::string syst_name;
-<<<<<<< HEAD
-        MyCorrection::variation variation;
-=======
         std::string syst_source;
         Correction::variation variation;
->>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
         void clone(Iter_obj &obj)
         {
             iter_name = obj.iter_name;
@@ -122,14 +114,9 @@ public:
     }
 
     inline std::string getCurrentSysName() const { return current_Iter_obj.iter_name; }
-<<<<<<< HEAD
-    inline std::string getCurrentIterSysSource() const { return current_Iter_obj.syst_name; }
-    inline MyCorrection::variation getCurrentIterVariation() const { return current_Iter_obj.variation; }
-=======
     inline std::string getCurrentIterSysTarget() const { return current_Iter_obj.syst_name; }
     inline std::string getCurrentIterSysSource() const { return current_Iter_obj.syst_source; }
     inline Correction::variation getCurrentIterVariation() const { return current_Iter_obj.variation; }
->>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
 
     std::vector<std::string> get_targets_from_name(const std::string &syst_name);
     std::vector<std::string> get_sources_from_name(const std::string &syst_name);

--- a/AnalyzerTools/include/SystematicHelper.h
+++ b/AnalyzerTools/include/SystematicHelper.h
@@ -41,7 +41,12 @@ public:
     {
         std::string iter_name;
         std::string syst_name;
+<<<<<<< HEAD
         MyCorrection::variation variation;
+=======
+        std::string syst_source;
+        Correction::variation variation;
+>>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
     };
 
 
@@ -49,11 +54,17 @@ public:
     {
         std::string iter_name;
         std::string syst_name;
+<<<<<<< HEAD
         MyCorrection::variation variation;
+=======
+        std::string syst_source;
+        Correction::variation variation;
+>>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
         void clone(Iter_obj &obj)
         {
             iter_name = obj.iter_name;
             syst_name = obj.syst_name;
+            syst_source = obj.syst_source;
             variation = obj.variation;
         }
     };
@@ -111,8 +122,14 @@ public:
     }
 
     inline std::string getCurrentSysName() const { return current_Iter_obj.iter_name; }
+<<<<<<< HEAD
     inline std::string getCurrentIterSysSource() const { return current_Iter_obj.syst_name; }
     inline MyCorrection::variation getCurrentIterVariation() const { return current_Iter_obj.variation; }
+=======
+    inline std::string getCurrentIterSysTarget() const { return current_Iter_obj.syst_name; }
+    inline std::string getCurrentIterSysSource() const { return current_Iter_obj.syst_source; }
+    inline Correction::variation getCurrentIterVariation() const { return current_Iter_obj.variation; }
+>>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
 
     std::vector<std::string> get_targets_from_name(const std::string &syst_name);
     std::vector<std::string> get_sources_from_name(const std::string &syst_name);

--- a/AnalyzerTools/noSyst.yaml
+++ b/AnalyzerTools/noSyst.yaml
@@ -1,0 +1,1 @@
+systematics:

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -360,7 +360,12 @@ float Correction::GetElectronTriggerSF(const TString &Electron_Trigger_SF_Key, c
     auto cset = cset_electron_hlt->at("Electron-HLT-SF");
     try
     {
-        return cset->evaluate({EGM_keys.at(DataEra.Data()), getSystString_EGM(syst), string(Electron_Trigger_SF_Key), eta, pt, phi});
+        if(cset->inputs().size() == 5){
+            return cset->evaluate({EGM_keys.at(DataEra.Data()), getSystString_EGM(syst), string(Electron_Trigger_SF_Key), eta, pt});
+        }
+        else{
+            return cset->evaluate({EGM_keys.at(DataEra.Data()), getSystString_EGM(syst), string(Electron_Trigger_SF_Key), eta, pt, phi});
+        }
     }
     catch (exception &e)
     {

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -485,12 +485,7 @@ float MyCorrection::GetBTaggingWP(JetTagging::JetFlavTagger tagger, JetTagging::
     }
 }
 
-<<<<<<< HEAD:AnalyzerTools/src/MyCorrection.cc
 float MyCorrection::GetBTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
-=======
-
-float Correction::GetBTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
->>>>>>> fix Hardcoded c-tagging Wp retriever:AnalyzerTools/src/Correction.cc
 {
     string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();
     string this_wpStr = JetTagging::GetTaggerCorrectionWPStr(wp).Data();

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -233,7 +233,7 @@ MyCorrection::MyCorrection(const TString &era, const TString &sample, const bool
     }
 
 
-    MUO_keys["2023BPix"] = "Collisions2023_369803_370790_eraD_GoldenJson";
+    LUM_keys["2023BPix"] = "Collisions2023_369803_370790_eraD_GoldenJson";
     LUM_keys["2023"] = "Collisions2023_366403_369802_eraBC_GoldenJson";
     LUM_keys["2022EE"] = "Collisions2022_359022_362760_eraEFG_GoldenJson";
     LUM_keys["2022"] = "Collisions2022_355100_357900_eraBCD_GoldenJson";
@@ -242,7 +242,7 @@ MyCorrection::MyCorrection(const TString &era, const TString &sample, const bool
     LUM_keys["2016postVFP"] = "Collisions16_UltraLegacy_goldenJSON";
     LUM_keys["2016preVFP"] = "Collisions16_UltraLegacy_goldenJSON";
 
-    BTV_keys["2023BPix"] = "2023PromptD";
+    EGM_keys["2023BPix"] = "2023PromptD";
     EGM_keys["2023"] = "2023PromptC";
     EGM_keys["2022EE"] = "2022Re-recoE+PromptFG";
     EGM_keys["2022"] = "2022ReRecoBCD";

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -324,7 +324,7 @@ float MyCorrection::GetMuonTriggerWeight(const TString &Muon_Trigger_SF_Key, con
     return weight;
 }
 
-float Correction::GetElectronIDSF(const TString &Electron_ID_SF_Key, const float eta, const float pt, const float phi, const variation syst, const TString &source) const
+float MyCorrection::GetElectronIDSF(const TString &Electron_ID_SF_Key, const float eta, const float pt, const float phi, const variation syst, const TString &source) const
 {
     auto cset = cset_electron->at("Electron-ID-SF");
     try
@@ -355,7 +355,7 @@ float MyCorrection::GetElectronIDSF(const TString &Electron_ID_SF_Key, const RVe
     return weight;
 }
 
-float Correction::GetElectronTriggerSF(const TString &Electron_Trigger_SF_Key, const float eta, const float pt, const float phi, const variation syst, const TString &source) const
+float MyCorrection::GetElectronTriggerSF(const TString &Electron_Trigger_SF_Key, const float eta, const float pt, const float phi, const variation syst, const TString &source) const
 {
     auto cset = cset_electron_hlt->at("Electron-HLT-SF");
     try
@@ -374,7 +374,7 @@ float Correction::GetElectronTriggerSF(const TString &Electron_Trigger_SF_Key, c
     }
 }
 
-float Correction::GetElectronTriggerEff(const TString &Electron_Trigger_SF_Key, const float eta, const float pt, const float phi, bool ofDATA, const variation syst, const TString &source) const
+float MyCorrection::GetElectronTriggerEff(const TString &Electron_Trigger_SF_Key, const float eta, const float pt, const float phi, bool ofDATA, const variation syst, const TString &source) const
 {
     std::string key = ofDATA ? "Electron-HLT-DataEff" : "Electron-HLT-McEff";
     auto cset = cset_electron_hlt->at(key);
@@ -404,7 +404,7 @@ float Correction::GetElectronTriggerEff(const TString &Electron_Trigger_SF_Key, 
     }
 }
 
-float Correction::GetElectronRECOSF(const float eta, const float pt, const float phi,const variation syst, const TString &source) const
+float MyCorrection::GetElectronRECOSF(const float eta, const float pt, const float phi,const variation syst, const TString &source) const
 {
     if (pt < 20.)
         return GetElectronIDSF("RecoBelow20", eta, pt, phi, syst);
@@ -632,7 +632,7 @@ pair<float, float> MyCorrection::GetCTaggingWP() const
 }
 
 
-pair<float, float> Correction::GetCTaggingWP(JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp) const
+pair<float, float> MyCorrection::GetCTaggingWP(JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp) const
 {
     // Convert enumerations to strings using your existing utility functions
     string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();
@@ -663,7 +663,7 @@ pair<float, float> Correction::GetCTaggingWP(JetTagging::JetFlavTagger tagger, J
 }
 
 
-float Correction::GetCTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
+float MyCorrection::GetCTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
 {
     return 1.;
     string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -331,7 +331,7 @@ float MyCorrection::GetElectronIDSF(const TString &Electron_ID_SF_Key, const flo
     {
         //NOTE: from 2023, It seems some SF depends on phi. I think it will gradually be applied to all SFs.
         //As a interim solution, I hardcode here.
-        if((cset->inputs().size() == 5)){
+        if(!isInputInCorrection("phi", cset)){
             return cset->evaluate({EGM_keys.at(DataEra.Data()), getSystString_EGM(syst), string(Electron_ID_SF_Key), eta, pt});
         }
         else{
@@ -360,7 +360,7 @@ float MyCorrection::GetElectronTriggerSF(const TString &Electron_Trigger_SF_Key,
     auto cset = cset_electron_hlt->at("Electron-HLT-SF");
     try
     {
-        if(cset->inputs().size() == 5){
+        if(!isInputInCorrection("phi", cset)){
             return cset->evaluate({EGM_keys.at(DataEra.Data()), getSystString_EGM(syst), string(Electron_Trigger_SF_Key), eta, pt});
         }
         else{
@@ -390,7 +390,7 @@ float MyCorrection::GetElectronTriggerEff(const TString &Electron_Trigger_SF_Key
         throw std::runtime_error("[MyCorrection::GetElectronTriggerEff] Invalid syst value");
     try
     {
-        if(cset->inputs().size() == 5){
+        if(!isInputInCorrection("phi", cset)){
             return cset->evaluate({EGM_keys.at(DataEra.Data()), ValType, string(Electron_Trigger_SF_Key), eta, pt});
         }
         else{
@@ -459,8 +459,8 @@ float MyCorrection::GetBTaggingWP() const
     catch (const std::exception &e)
     {
         std::cerr << "[Correction::GetBTaggingWP] Warning: Failed to evaluate WP '"
-                  << global_wpStr << "' for tagger '" << global_taggerStr
-                  << "'. Returning 1.f as default." << std::endl;
+                  << global_wpStr << "' for tagger '" << global_taggerStr << std::endl;
+        throw std::runtime_error(e.what());
         return 1.f;
     }
 }
@@ -479,8 +479,8 @@ float MyCorrection::GetBTaggingWP(JetTagging::JetFlavTagger tagger, JetTagging::
     catch (const std::exception &e)
     {
         std::cerr << "[Correction::GetBTaggingWP] Warning: Failed to evaluate WP '"
-                  << this_wpStr << "' for tagger '" << this_taggerStr
-                  << "'. Returning 1.f as default." << std::endl;
+                  << this_wpStr << "' for tagger '" << this_taggerStr << std::endl;
+        throw std::runtime_error(e.what());
         return 1.f;
     }
 }
@@ -626,7 +626,8 @@ pair<float, float> MyCorrection::GetCTaggingWP() const
         // log a warning and return (1.f, 1.f) as a fallback.
         cerr << "[Correction::GetCTaggingWP] Warning: Failed to evaluate WP '"
              << global_wpStr << "' for tagger '" << global_taggerStr
-             << "'. Returning (1.f, 1.f) as default." << endl;
+             << endl;
+        throw std::runtime_error(e.what());
         return make_pair(1.f, 1.f);
     }
 }
@@ -656,8 +657,8 @@ pair<float, float> MyCorrection::GetCTaggingWP(JetTagging::JetFlavTagger tagger,
         // print a warning (optional) and return default values
         std::cerr << "[Correction::GetCTaggingWP] Warning: WP '" 
                   << this_wpStr << "' not found for tagger '"
-                  << this_taggerStr << "'. Returning (1.f, 1.f) as default."
-                  << std::endl;
+                  << this_taggerStr << std::endl;
+        throw std::runtime_error(e.what());
         return make_pair(1.f, 1.f);
     }
 }

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -451,19 +451,46 @@ void MyCorrection::SetTaggingParam(JetTagging::JetFlavTagger tagger, JetTagging:
 
 float MyCorrection::GetBTaggingWP() const
 {
-    correction::Correction::Ref cset = cset_btagging->at(global_taggerStr + "_wp_values");
-    return cset->evaluate({global_wpStr});
+    try
+    {
+        correction::Correction::Ref cset = cset_btagging->at(global_taggerStr + "_wp_values");
+        return cset->evaluate({global_wpStr});
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "[Correction::GetBTaggingWP] Warning: Failed to evaluate WP '"
+                  << global_wpStr << "' for tagger '" << global_taggerStr
+                  << "'. Returning 1.f as default." << std::endl;
+        return 1.f;
+    }
 }
 
 float MyCorrection::GetBTaggingWP(JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp) const
 {
-    string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();
-    string this_wpStr = JetTagging::GetTaggerCorrectionWPStr(wp).Data();
-    correction::Correction::Ref cset = cset_btagging->at(this_taggerStr + "_wp_values");
-    return cset->evaluate({this_wpStr});
+    // Convert enumerations to strings
+    std::string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();
+    std::string this_wpStr     = JetTagging::GetTaggerCorrectionWPStr(wp).Data();
+
+    try
+    {
+        correction::Correction::Ref cset = cset_btagging->at(this_taggerStr + "_wp_values");
+        return cset->evaluate({this_wpStr});
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "[Correction::GetBTaggingWP] Warning: Failed to evaluate WP '"
+                  << this_wpStr << "' for tagger '" << this_taggerStr
+                  << "'. Returning 1.f as default." << std::endl;
+        return 1.f;
+    }
 }
 
+<<<<<<< HEAD:AnalyzerTools/src/MyCorrection.cc
 float MyCorrection::GetBTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
+=======
+
+float Correction::GetBTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
+>>>>>>> fix Hardcoded c-tagging Wp retriever:AnalyzerTools/src/Correction.cc
 {
     string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();
     string this_wpStr = JetTagging::GetTaggerCorrectionWPStr(wp).Data();
@@ -591,29 +618,57 @@ float MyCorrection::GetBTaggingR(const RVec<Jet> &jets, const JetTagging::JetFla
 
 pair<float, float> MyCorrection::GetCTaggingWP() const
 {
-    if ((int)global_wp >= 3)
+    try
     {
-        cout << "[MyCorrection::GetCTaggingWP] Workingpoint VeryTight and SuperTight are not available for C-Tagging" << endl;
-        exit(ENODATA);
+        correction::Correction::Ref cset = cset_ctagging->at(global_taggerStr + "_wp_values");
+        float valCvB = cset->evaluate({global_wpStr, "CvB"});
+        float valCvL = cset->evaluate({global_wpStr, "CvL"});
+        return make_pair(valCvB, valCvL);
     }
-    correction::Correction::Ref cset = cset_ctagging->at(global_taggerStr + "_wp_values");
-    return make_pair(cset->evaluate({global_wpStr, "CvB"}), cset->evaluate({global_wpStr, "CvL"}));
+    catch (const std::exception& e)
+    {
+        // If the requested WP is not found or any other error occurs, 
+        // log a warning and return (1.f, 1.f) as a fallback.
+        cerr << "[Correction::GetCTaggingWP] Warning: Failed to evaluate WP '"
+             << global_wpStr << "' for tagger '" << global_taggerStr
+             << "'. Returning (1.f, 1.f) as default." << endl;
+        return make_pair(1.f, 1.f);
+    }
 }
 
-pair<float, float> MyCorrection::GetCTaggingWP(JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp) const
+
+pair<float, float> Correction::GetCTaggingWP(JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp) const
 {
+    // Convert enumerations to strings using your existing utility functions
     string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();
-    string this_wpStr = JetTagging::GetTaggerCorrectionWPStr(wp).Data();
-    if ((int)wp >= 3)
-    {
-        cout << "[MyCorrection::GetCTaggingWP] Workingpoint VeryTight and SuperTight are not available for C-Tagging" << endl;
-        exit(ENODATA);
-    }
+    string this_wpStr     = JetTagging::GetTaggerCorrectionWPStr(wp).Data();
+
+    // Retrieve the relevant correction set
     correction::Correction::Ref cset = cset_ctagging->at(this_taggerStr + "_wp_values");
-    return make_pair(cset->evaluate({this_wpStr, "CvB"}), cset->evaluate({this_wpStr, "CvL"}));
+
+    try
+    {
+        // Evaluate the corrections. If the WP does not exist, an exception might be thrown
+        float valCvB = cset->evaluate({this_wpStr, "CvB"});
+        float valCvL = cset->evaluate({this_wpStr, "CvL"});
+
+        // If everything is fine, return the pair
+        return make_pair(valCvB, valCvL);
+    }
+    catch (const std::exception& e)
+    {
+        // In case the WP is not found (or any other error occurs),
+        // print a warning (optional) and return default values
+        std::cerr << "[Correction::GetCTaggingWP] Warning: WP '" 
+                  << this_wpStr << "' not found for tagger '"
+                  << this_taggerStr << "'. Returning (1.f, 1.f) as default."
+                  << std::endl;
+        return make_pair(1.f, 1.f);
+    }
 }
 
-float MyCorrection::GetCTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
+
+float Correction::GetCTaggingEff(const float eta, const float pt, const int flav, JetTagging::JetFlavTagger tagger, JetTagging::JetFlavTaggerWP wp, const variation syst)
 {
     return 1.;
     string this_taggerStr = JetTagging::GetTaggerCorrectionLibStr(tagger).Data();

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -390,7 +390,12 @@ float Correction::GetElectronTriggerEff(const TString &Electron_Trigger_SF_Key, 
         throw std::runtime_error("[MyCorrection::GetElectronTriggerEff] Invalid syst value");
     try
     {
-        return cset->evaluate({EGM_keys.at(DataEra.Data()), ValType, string(Electron_Trigger_SF_Key), eta, pt, phi});
+        if(cset->inputs().size() == 5){
+            return cset->evaluate({EGM_keys.at(DataEra.Data()), ValType, string(Electron_Trigger_SF_Key), eta, pt});
+        }
+        else{
+            return cset->evaluate({EGM_keys.at(DataEra.Data()), ValType, string(Electron_Trigger_SF_Key), eta, pt, phi});
+        }
     }
     catch (exception &e)
     {

--- a/AnalyzerTools/src/MyCorrection.cc
+++ b/AnalyzerTools/src/MyCorrection.cc
@@ -273,8 +273,8 @@ MyCorrection::MyCorrection(const TString &era, const TString &sample, const bool
     JME_JES_GT["2016postVFP"] = "Summer19UL16APV_V7_MC_######_AK4PFchs";
     JME_JES_GT["2016preVFP"] = "Summer19UL16_V7_MC_V5_MC_######_AK4PFchs";
 
-    JME_MET_keys["2023BPix"] = "Summer23BPixPrompt23_RunD_V1";
-    JME_MET_keys["2023"] = "Summer23Prompt23_RunC_V1";
+    JME_vetomap_keys["2023BPix"] = "Summer23BPixPrompt23_RunD_V1";
+    JME_vetomap_keys["2023"] = "Summer23Prompt23_RunC_V1";
     JME_vetomap_keys["2022EE"] = "Summer22EE_23Sep2023_RunEFG_V1";
     JME_vetomap_keys["2022"] = "Summer22_23Sep2023_RunBCD_V1";
     JME_vetomap_keys["2018"] = "Summer19UL18_V1";

--- a/AnalyzerTools/src/SystematicHepler.cc
+++ b/AnalyzerTools/src/SystematicHepler.cc
@@ -158,7 +158,7 @@ void SystematicHelper::make_Iter_obj_EvtLoopAgain()
     obj_central.iter_name = central_name;
     obj_central.syst_name = central_name;
     obj_central.syst_source = "total";
-    obj_central.variation = Correction::variation::nom;
+    obj_central.variation = MyCorrection::variation::nom;
     systematics_evtLoopAgain.push_back(obj_central);
 
     // if systematic sample is provided, only loop over central
@@ -175,10 +175,10 @@ void SystematicHelper::make_Iter_obj_EvtLoopAgain()
             obj_down.iter_name = syst.syst + variation_prefix[MyCorrection::variation::down];
             obj_up.syst_name = syst.syst;
             obj_up.syst_source = syst.source;
-            obj_up.variation = Correction::variation::up;
+            obj_up.variation = MyCorrection::variation::up;
             obj_down.syst_name = syst.syst;
             obj_down.syst_source = syst.source;
-            obj_down.variation = Correction::variation::down;
+            obj_down.variation = MyCorrection::variation::down;
 
             systematics_evtLoopAgain.push_back(obj_up);
             systematics_evtLoopAgain.push_back(obj_down);

--- a/AnalyzerTools/src/SystematicHepler.cc
+++ b/AnalyzerTools/src/SystematicHepler.cc
@@ -157,7 +157,12 @@ void SystematicHelper::make_Iter_obj_EvtLoopAgain()
     SystematicHelper::Iter_obj obj_central;
     obj_central.iter_name = central_name;
     obj_central.syst_name = central_name;
+<<<<<<< HEAD
     obj_central.variation = MyCorrection::variation::nom;
+=======
+    obj_central.syst_source = "total";
+    obj_central.variation = Correction::variation::nom;
+>>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
     systematics_evtLoopAgain.push_back(obj_central);
 
     // if systematic sample is provided, only loop over central
@@ -173,9 +178,17 @@ void SystematicHelper::make_Iter_obj_EvtLoopAgain()
             obj_up.iter_name = syst.syst + variation_prefix[MyCorrection::variation::up];
             obj_down.iter_name = syst.syst + variation_prefix[MyCorrection::variation::down];
             obj_up.syst_name = syst.syst;
+<<<<<<< HEAD
             obj_up.variation = MyCorrection::variation::up;
             obj_down.syst_name = syst.syst;
             obj_down.variation = MyCorrection::variation::down;
+=======
+            obj_up.syst_source = syst.source;
+            obj_up.variation = Correction::variation::up;
+            obj_down.syst_name = syst.syst;
+            obj_down.syst_source = syst.source;
+            obj_down.variation = Correction::variation::down;
+>>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
 
             systematics_evtLoopAgain.push_back(obj_up);
             systematics_evtLoopAgain.push_back(obj_down);

--- a/AnalyzerTools/src/SystematicHepler.cc
+++ b/AnalyzerTools/src/SystematicHepler.cc
@@ -157,12 +157,8 @@ void SystematicHelper::make_Iter_obj_EvtLoopAgain()
     SystematicHelper::Iter_obj obj_central;
     obj_central.iter_name = central_name;
     obj_central.syst_name = central_name;
-<<<<<<< HEAD
-    obj_central.variation = MyCorrection::variation::nom;
-=======
     obj_central.syst_source = "total";
     obj_central.variation = Correction::variation::nom;
->>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
     systematics_evtLoopAgain.push_back(obj_central);
 
     // if systematic sample is provided, only loop over central
@@ -178,17 +174,11 @@ void SystematicHelper::make_Iter_obj_EvtLoopAgain()
             obj_up.iter_name = syst.syst + variation_prefix[MyCorrection::variation::up];
             obj_down.iter_name = syst.syst + variation_prefix[MyCorrection::variation::down];
             obj_up.syst_name = syst.syst;
-<<<<<<< HEAD
-            obj_up.variation = MyCorrection::variation::up;
-            obj_down.syst_name = syst.syst;
-            obj_down.variation = MyCorrection::variation::down;
-=======
             obj_up.syst_source = syst.source;
             obj_up.variation = Correction::variation::up;
             obj_down.syst_name = syst.syst;
             obj_down.syst_source = syst.source;
             obj_down.variation = Correction::variation::down;
->>>>>>> add getCurrentIterSysSource, getCurrentIterSysTarget
 
             systematics_evtLoopAgain.push_back(obj_up);
             systematics_evtLoopAgain.push_back(obj_down);

--- a/Analyzers/src/AnalyzerCore.cc
+++ b/Analyzers/src/AnalyzerCore.cc
@@ -56,10 +56,10 @@ float AnalyzerCore::GetScaleVariation(const MyCorrection::variation &muF_syst, c
 float AnalyzerCore::GetPSWeight(const MyCorrection::variation &ISR_syst, const MyCorrection::variation &FSR_syst){
     //[0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;
     if(nPSWeight == 1) return 1.;
-    if(ISR_syst == Correction::variation::up && FSR_syst == Correction::variation::nom) return PSWeight[0];
-    else if(ISR_syst == Correction::variation::nom && FSR_syst == Correction::variation::up) return PSWeight[1];
-    else if(ISR_syst == Correction::variation::down && FSR_syst == Correction::variation::nom) return PSWeight[2];
-    else if(ISR_syst == Correction::variation::nom && FSR_syst == Correction::variation::down) return PSWeight[3];
+    if(ISR_syst == MyCorrection::variation::up && FSR_syst == MyCorrection::variation::nom) return PSWeight[0];
+    else if(ISR_syst == MyCorrection::variation::nom && FSR_syst == MyCorrection::variation::up) return PSWeight[1];
+    else if(ISR_syst == MyCorrection::variation::down && FSR_syst == MyCorrection::variation::nom) return PSWeight[2];
+    else if(ISR_syst == MyCorrection::variation::nom && FSR_syst == MyCorrection::variation::down) return PSWeight[3];
     else{
         cout << "[AnalyzerCore::GetPSWeight] ISR_syst = " << int(ISR_syst) << " and FSR_syst = " << int(FSR_syst) << " is not implemented" << endl;
         exit(ENODATA);

--- a/Analyzers/src/AnalyzerCore.cc
+++ b/Analyzers/src/AnalyzerCore.cc
@@ -55,10 +55,18 @@ float AnalyzerCore::GetScaleVariation(const MyCorrection::variation &muF_syst, c
 
 float AnalyzerCore::GetPSWeight(const MyCorrection::variation &ISR_syst, const MyCorrection::variation &FSR_syst){
     //[0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;
+<<<<<<< HEAD
     if(ISR_syst == MyCorrection::variation::up && FSR_syst == MyCorrection::variation::nom) return PSWeight[0];
     else if(ISR_syst == MyCorrection::variation::nom && FSR_syst == MyCorrection::variation::up) return PSWeight[1];
     else if(ISR_syst == MyCorrection::variation::down && FSR_syst == MyCorrection::variation::nom) return PSWeight[2];
     else if(ISR_syst == MyCorrection::variation::nom && FSR_syst == MyCorrection::variation::down) return PSWeight[3];
+=======
+    if(nPSWeight == 1) return 1.;
+    if(ISR_syst == Correction::variation::up && FSR_syst == Correction::variation::nom) return PSWeight[0];
+    else if(ISR_syst == Correction::variation::nom && FSR_syst == Correction::variation::up) return PSWeight[1];
+    else if(ISR_syst == Correction::variation::down && FSR_syst == Correction::variation::nom) return PSWeight[2];
+    else if(ISR_syst == Correction::variation::nom && FSR_syst == Correction::variation::down) return PSWeight[3];
+>>>>>>> nPSWeight=1 check for pythia sample
     else{
         cout << "[AnalyzerCore::GetPSWeight] ISR_syst = " << int(ISR_syst) << " and FSR_syst = " << int(FSR_syst) << " is not implemented" << endl;
         exit(ENODATA);

--- a/Analyzers/src/AnalyzerCore.cc
+++ b/Analyzers/src/AnalyzerCore.cc
@@ -55,18 +55,11 @@ float AnalyzerCore::GetScaleVariation(const MyCorrection::variation &muF_syst, c
 
 float AnalyzerCore::GetPSWeight(const MyCorrection::variation &ISR_syst, const MyCorrection::variation &FSR_syst){
     //[0] is ISR=2 FSR=1; [1] is ISR=1 FSR=2[2] is ISR=0.5 FSR=1; [3] is ISR=1 FSR=0.5;
-<<<<<<< HEAD
-    if(ISR_syst == MyCorrection::variation::up && FSR_syst == MyCorrection::variation::nom) return PSWeight[0];
-    else if(ISR_syst == MyCorrection::variation::nom && FSR_syst == MyCorrection::variation::up) return PSWeight[1];
-    else if(ISR_syst == MyCorrection::variation::down && FSR_syst == MyCorrection::variation::nom) return PSWeight[2];
-    else if(ISR_syst == MyCorrection::variation::nom && FSR_syst == MyCorrection::variation::down) return PSWeight[3];
-=======
     if(nPSWeight == 1) return 1.;
     if(ISR_syst == Correction::variation::up && FSR_syst == Correction::variation::nom) return PSWeight[0];
     else if(ISR_syst == Correction::variation::nom && FSR_syst == Correction::variation::up) return PSWeight[1];
     else if(ISR_syst == Correction::variation::down && FSR_syst == Correction::variation::nom) return PSWeight[2];
     else if(ISR_syst == Correction::variation::nom && FSR_syst == Correction::variation::down) return PSWeight[3];
->>>>>>> nPSWeight=1 check for pythia sample
     else{
         cout << "[AnalyzerCore::GetPSWeight] ISR_syst = " << int(ISR_syst) << " and FSR_syst = " << int(FSR_syst) << " is not implemented" << endl;
         exit(ENODATA);

--- a/Analyzers/src/MeasureJetTaggingEff.cc
+++ b/Analyzers/src/MeasureJetTaggingEff.cc
@@ -76,9 +76,8 @@ void MeasureJetTaggingEff::executeEvent()
 
     //define your analysis phase space here
     RVec<Jet> jets = SelectJets(AllJets, Jet::JetID::TIGHT, 25., 2.5);
-    // if (jets.size() < 4)
-    //     return;
-    //     ..etc
+    if (jets.size() < )
+        return;
 
     float weight = 1.;
     float w_Gen = MCweight();
@@ -102,6 +101,7 @@ void MeasureJetTaggingEff::executeEvent()
 
         //==== First, fill the denominator
         FillHist(string("tagging#b") + "##era#" + DataEra.Data() + "##flavor#" + string(flav) + "##systematic#central##den", this_Eta, this_Pt, weight, NEtaBin, etabins, NPtBin, ptbins);
+        FillHist(string("tagging#c") + "##era#" + DataEra.Data() + "##flavor#" + string(flav) + "##systematic#central##den", this_Eta, this_Pt, weight, NEtaBin, etabins, NPtBin, ptbins);
         FillHist("DeepJetBTaggingScore"+flav, jets.at(ij).GetBTaggerResult(JetTagging::JetFlavTagger::DeepJet), weight, 100, 0, 1);
         FillHist("ParticleNetBTaggingScore"+flav, jets.at(ij).GetBTaggerResult(JetTagging::JetFlavTagger::ParticleNet), weight, 100, 0, 1);
         FillHist("ParTBTaggingScore"+flav, jets.at(ij).GetBTaggerResult(JetTagging::JetFlavTagger::ParT), weight, 100, 0, 1);

--- a/Analyzers/src/MeasureJetTaggingEff.cc
+++ b/Analyzers/src/MeasureJetTaggingEff.cc
@@ -44,7 +44,7 @@ void MeasureJetTaggingEff::initializeAnalyzer()
 
 
     vec_etabins = {0.0, 0.8, 1.6, 2., 2.5};
-    vec_ptbins = {20., 30., 50., 70., 100., 140., 200., 300., 600., 1000.}; // PT bins used in POG SF measurements
+    vec_ptbins = {20., 25., 30., 50., 70., 100., 140., 200., 300., 600., 1000.}; // PT bins used in POG SF measurements
     // for average users, this binning will be sufficient.
     // but eta-dependence of efficiency can be larger for |eta|>~2, where track & muon detector information of jet constituents starts to get lost, which is critical in tagging.
     // precision analysis with high-eta b may use finer binnings there, but beware of small number of b-jets in high-eta, high-pt bins if you use ttbar sample; proper optimization of bin size should be studied.
@@ -70,7 +70,16 @@ void MeasureJetTaggingEff::executeEvent()
     RVec<Jet> AllJets = GetAllJets();
     RVec<Muon> AllMuons = GetAllMuons();
     if(!PassJetVetoMap(AllJets,AllMuons)) return;
-    RVec<Jet> jets = SelectJets(AllJets, "tightLepVeto", 20., 2.5);
+
+    float JetPtCut = 25.;
+    float JetEtaCut = 2.4;
+
+    //define your analysis phase space here
+    RVec<Jet> jets = SelectJets(AllJets, Jet::JetID::TIGHT, 25., 2.5);
+    // if (jets.size() < 4)
+    //     return;
+    //     ..etc
+
     float weight = 1.;
     float w_Gen = MCweight();
     float w_Norm = ev.GetTriggerLumi("Full");
@@ -105,8 +114,6 @@ void MeasureJetTaggingEff::executeEvent()
                 if (jets.at(ij).GetBTaggerResult(this_tagger) > this_bTaggingCut)
                     FillHist(string("tagging#b") + "##era#" + DataEra.Data() + "##tagger#" + JetTagging::GetTaggerCorrectionLibStr(this_tagger).Data() + "##working_point#" + JetTagging::GetTaggerCorrectionWPStr(this_wp).Data() + "##flavor#" + string(flav) + "##systematic#central##num", this_Eta, this_Pt, weight, NEtaBin, etabins, NPtBin, ptbins);
                 //No XT and XXT for c-tagging
-                if(this_wp == JetTagging::JetFlavTaggerWP::VeryTight) continue;
-                if(this_wp == JetTagging::JetFlavTaggerWP::SuperTight) continue;
                 float this_CvBCut = myCorr->GetCTaggingWP().first;
                 float this_CvLCut = myCorr->GetCTaggingWP().second;
                 if (jets.at(ij).GetCTaggerResult(this_tagger).first > this_CvBCut && jets.at(ij).GetCTaggerResult(this_tagger).second > this_CvLCut)

--- a/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 49466000.0,
         "sumW": 49466000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 50896000.0,
         "sumW": 50896000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 50748000.0,
         "sumW": 50748000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 73284000.0,
         "sumW": 73289856.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 54668000.0,
         "sumW": 54668500.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 63970000.0,
         "sumW": 63970000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 125642000.0,
         "sumW": 125642000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 112224000.0,
         "sumW": 112224096.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 123258000.0,
         "sumW": 123258000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 82516000.0,
         "sumW": 82516000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 35526000.0,
         "sumW": 35526000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 16044000.0,
         "sumW": 16044000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 7638000.0,
         "sumW": 7638000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 2848000.0,
         "sumW": 2848000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 49466000.0,
         "sumW": 49466000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 50896000.0,
         "sumW": 50896000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 50748000.0,
         "sumW": 50748000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 73284000.0,
         "sumW": 73289856.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 54668000.0,
         "sumW": 54668500.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 63970000.0,
         "sumW": 63970000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 125642000.0,
         "sumW": 125642000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 112224000.0,
         "sumW": 112224096.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 123258000.0,
         "sumW": 123258000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 82516000.0,
         "sumW": 82516000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 35526000.0,
         "sumW": 35526000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 16044000.0,
         "sumW": 16044000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 7638000.0,
         "sumW": 7638000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 2848000.0,
         "sumW": 2848000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_PT_15to30": {
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 49466000.0,
         "sumW": 49466000.0
     },
-    "QCD_PT_30to50": {
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 50896000.0,
         "sumW": 50896000.0
     },
-    "QCD_PT_50to80": {
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 50748000.0,
         "sumW": 50748000.0
     },
-    "QCD_PT_80to120": {
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 73284000.0,
         "sumW": 73289856.0
     },
-    "QCD_PT_120to170": {
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 54668000.0,
         "sumW": 54668500.0
     },
-    "QCD_PT_170to300": {
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 63970000.0,
         "sumW": 63970000.0
     },
-    "QCD_PT_300to470": {
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 125642000.0,
         "sumW": 125642000.0
     },
-    "QCD_PT_470to600": {
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 112224000.0,
         "sumW": 112224096.0
     },
-    "QCD_PT_600to800": {
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 123258000.0,
         "sumW": 123258000.0
     },
-    "QCD_PT_800to1000": {
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 82516000.0,
         "sumW": 82516000.0
     },
-    "QCD_PT_1000to1400": {
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 35526000.0,
         "sumW": 35526000.0
     },
-    "QCD_PT_1400to1800": {
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 16044000.0,
         "sumW": 16044000.0
     },
-    "QCD_PT_1800to2400": {
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 7638000.0,
         "sumW": 7638000.0
     },
-    "QCD_PT_2400to3200": {
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 2848000.0,
         "sumW": 2848000.0
     },
-    "QCD_PT_3200toInf": {
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 49466000.0,
         "sumW": 49466000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 50896000.0,
         "sumW": 50896000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 50748000.0,
         "sumW": 50748000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 73284000.0,
         "sumW": 73289856.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 54668000.0,
         "sumW": 54668500.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 63970000.0,
         "sumW": 63970000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 125642000.0,
         "sumW": 125642000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 112224000.0,
         "sumW": 112224096.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 123258000.0,
         "sumW": 123258000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 82516000.0,
         "sumW": 82516000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 35526000.0,
         "sumW": 35526000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 16044000.0,
         "sumW": 16044000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 7638000.0,
         "sumW": 7638000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 2848000.0,
         "sumW": 2848000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016postVFP/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 49466000.0,
         "sumW": 49466000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 50896000.0,
         "sumW": 50896000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 50748000.0,
         "sumW": 50748000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 73284000.0,
         "sumW": 73289856.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 54668000.0,
         "sumW": 54668500.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 63970000.0,
         "sumW": 63970000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 125642000.0,
         "sumW": 125642000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 112224000.0,
         "sumW": 112224096.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 123258000.0,
         "sumW": 123258000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 82516000.0,
         "sumW": 82516000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 35526000.0,
         "sumW": 35526000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 16044000.0,
         "sumW": 16044000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 7638000.0,
         "sumW": 7638000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 2848000.0,
         "sumW": 2848000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 668223.0,
         "sumW": 668223.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 53458000.0,
         "sumW": 53458000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 48762000.0,
         "sumW": 48762000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 50650000.0,
         "sumW": 50650000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 77363000.0,
         "sumW": 77369192.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 67728000.0,
         "sumW": 67728576.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 63426000.0,
         "sumW": 63426000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 116340000.0,
         "sumW": 116340000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 109500000.0,
         "sumW": 109500096.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 117329000.0,
         "sumW": 117329000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 66529000.0,
         "sumW": 66529000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 38009000.0,
         "sumW": 38009000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 18433000.0,
         "sumW": 18433000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 8141000.0,
         "sumW": 8141000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 3067000.0,
         "sumW": 3067000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 668223.0,
         "sumW": 668223.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 53458000.0,
         "sumW": 53458000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 48762000.0,
         "sumW": 48762000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 50650000.0,
         "sumW": 50650000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 77363000.0,
         "sumW": 77369192.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 67728000.0,
         "sumW": 67728576.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 63426000.0,
         "sumW": 63426000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 116340000.0,
         "sumW": 116340000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 109500000.0,
         "sumW": 109500096.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 117329000.0,
         "sumW": 117329000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 66529000.0,
         "sumW": 66529000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 38009000.0,
         "sumW": 38009000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 18433000.0,
         "sumW": 18433000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 8141000.0,
         "sumW": 8141000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 3067000.0,
         "sumW": 3067000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 668223.0,
         "sumW": 668223.0
     },
-    "QCD_PT_15to30": {
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 53458000.0,
         "sumW": 53458000.0
     },
-    "QCD_PT_30to50": {
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 48762000.0,
         "sumW": 48762000.0
     },
-    "QCD_PT_50to80": {
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 50650000.0,
         "sumW": 50650000.0
     },
-    "QCD_PT_80to120": {
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 77363000.0,
         "sumW": 77369192.0
     },
-    "QCD_PT_120to170": {
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 67728000.0,
         "sumW": 67728576.0
     },
-    "QCD_PT_170to300": {
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 63426000.0,
         "sumW": 63426000.0
     },
-    "QCD_PT_300to470": {
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 116340000.0,
         "sumW": 116340000.0
     },
-    "QCD_PT_470to600": {
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 109500000.0,
         "sumW": 109500096.0
     },
-    "QCD_PT_600to800": {
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 117329000.0,
         "sumW": 117329000.0
     },
-    "QCD_PT_800to1000": {
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 66529000.0,
         "sumW": 66529000.0
     },
-    "QCD_PT_1000to1400": {
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 38009000.0,
         "sumW": 38009000.0
     },
-    "QCD_PT_1400to1800": {
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 18433000.0,
         "sumW": 18433000.0
     },
-    "QCD_PT_1800to2400": {
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 8141000.0,
         "sumW": 8141000.0
     },
-    "QCD_PT_2400to3200": {
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 3067000.0,
         "sumW": 3067000.0
     },
-    "QCD_PT_3200toInf": {
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 668223.0,
         "sumW": 668223.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 53458000.0,
         "sumW": 53458000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 48762000.0,
         "sumW": 48762000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 50650000.0,
         "sumW": 50650000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 77363000.0,
         "sumW": 77369192.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 67728000.0,
         "sumW": 67728576.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 63426000.0,
         "sumW": 63426000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 116340000.0,
         "sumW": 116340000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 109500000.0,
         "sumW": 109500096.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 117329000.0,
         "sumW": 117329000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 66529000.0,
         "sumW": 66529000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 38009000.0,
         "sumW": 38009000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 18433000.0,
         "sumW": 18433000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 8141000.0,
         "sumW": 8141000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 3067000.0,
         "sumW": 3067000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2016preVFP/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 668223.0,
         "sumW": 668223.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 53458000.0,
         "sumW": 53458000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 48762000.0,
         "sumW": 48762000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 50650000.0,
         "sumW": 50650000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 77363000.0,
         "sumW": 77369192.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 67728000.0,
         "sumW": 67728576.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 63426000.0,
         "sumW": 63426000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 116340000.0,
         "sumW": 116340000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 109500000.0,
         "sumW": 109500096.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 117329000.0,
         "sumW": 117329000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 66529000.0,
         "sumW": 66529000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 38009000.0,
         "sumW": 38009000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 18433000.0,
         "sumW": 18433000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 8141000.0,
         "sumW": 8141000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 3067000.0,
         "sumW": 3067000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 56635000.0,
         "sumW": 56635000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 52731000.0,
         "sumW": 52731000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 51699000.0,
         "sumW": 51699000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 70713000.0,
         "sumW": 70718808.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 46281000.0,
         "sumW": 46281484.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 66257000.0,
         "sumW": 66257000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 101590000.0,
         "sumW": 101590000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 92533000.0,
         "sumW": 92533120.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 115591000.0,
         "sumW": 115591000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 75393000.0,
         "sumW": 75393000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 26467000.0,
         "sumW": 26467000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 11000000.0,
         "sumW": 11000000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 5770000.0,
         "sumW": 5770000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 2997000.0,
         "sumW": 2997000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 56635000.0,
         "sumW": 56635000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 52731000.0,
         "sumW": 52731000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 51699000.0,
         "sumW": 51699000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 70713000.0,
         "sumW": 70718808.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 46281000.0,
         "sumW": 46281484.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 66257000.0,
         "sumW": 66257000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 101590000.0,
         "sumW": 101590000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 92533000.0,
         "sumW": 92533120.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 115591000.0,
         "sumW": 115591000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 75393000.0,
         "sumW": 75393000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 26467000.0,
         "sumW": 26467000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 11000000.0,
         "sumW": 11000000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 5770000.0,
         "sumW": 5770000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 2997000.0,
         "sumW": 2997000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 56635000.0,
         "sumW": 56635000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 52731000.0,
         "sumW": 52731000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 51699000.0,
         "sumW": 51699000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 70713000.0,
         "sumW": 70718808.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 46281000.0,
         "sumW": 46281484.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 66257000.0,
         "sumW": 66257000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 101590000.0,
         "sumW": 101590000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 92533000.0,
         "sumW": 92533120.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 115591000.0,
         "sumW": 115591000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 75393000.0,
         "sumW": 75393000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 26467000.0,
         "sumW": 26467000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 11000000.0,
         "sumW": 11000000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 5770000.0,
         "sumW": 5770000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 2997000.0,
         "sumW": 2997000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_PT_15to30": {
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 56635000.0,
         "sumW": 56635000.0
     },
-    "QCD_PT_30to50": {
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 52731000.0,
         "sumW": 52731000.0
     },
-    "QCD_PT_50to80": {
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 51699000.0,
         "sumW": 51699000.0
     },
-    "QCD_PT_80to120": {
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 70713000.0,
         "sumW": 70718808.0
     },
-    "QCD_PT_120to170": {
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 46281000.0,
         "sumW": 46281484.0
     },
-    "QCD_PT_170to300": {
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 66257000.0,
         "sumW": 66257000.0
     },
-    "QCD_PT_300to470": {
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 101590000.0,
         "sumW": 101590000.0
     },
-    "QCD_PT_470to600": {
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 92533000.0,
         "sumW": 92533120.0
     },
-    "QCD_PT_600to800": {
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 115591000.0,
         "sumW": 115591000.0
     },
-    "QCD_PT_800to1000": {
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 75393000.0,
         "sumW": 75393000.0
     },
-    "QCD_PT_1000to1400": {
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 26467000.0,
         "sumW": 26467000.0
     },
-    "QCD_PT_1400to1800": {
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 11000000.0,
         "sumW": 11000000.0
     },
-    "QCD_PT_1800to2400": {
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 5770000.0,
         "sumW": 5770000.0
     },
-    "QCD_PT_2400to3200": {
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 2997000.0,
         "sumW": 2997000.0
     },
-    "QCD_PT_3200toInf": {
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2017/Sample/CommonSampleInfo.json
@@ -233,7 +233,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -241,7 +241,7 @@
         "sumsign": 56635000.0,
         "sumW": 56635000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -249,7 +249,7 @@
         "sumsign": 52731000.0,
         "sumW": 52731000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -257,7 +257,7 @@
         "sumsign": 51699000.0,
         "sumW": 51699000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -265,7 +265,7 @@
         "sumsign": 70713000.0,
         "sumW": 70718808.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -273,7 +273,7 @@
         "sumsign": 46281000.0,
         "sumW": 46281484.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -281,7 +281,7 @@
         "sumsign": 66257000.0,
         "sumW": 66257000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -289,7 +289,7 @@
         "sumsign": 101590000.0,
         "sumW": 101590000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -297,7 +297,7 @@
         "sumsign": 92533000.0,
         "sumW": 92533120.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -305,7 +305,7 @@
         "sumsign": 115591000.0,
         "sumW": 115591000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -313,7 +313,7 @@
         "sumsign": 75393000.0,
         "sumW": 75393000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -321,7 +321,7 @@
         "sumsign": 26467000.0,
         "sumW": 26467000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -329,7 +329,7 @@
         "sumsign": 11000000.0,
         "sumW": 11000000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -337,7 +337,7 @@
         "sumsign": 5770000.0,
         "sumW": 5770000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -345,7 +345,7 @@
         "sumsign": 2997000.0,
         "sumW": 2997000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 39772000.0,
         "sumW": 39772000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 40767000.0,
         "sumW": 40767000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 37307000.0,
         "sumW": 37307000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 75573000.0,
         "sumW": 75578936.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 57954000.0,
         "sumW": 57954552.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 56307000.0,
         "sumW": 56307000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 108269000.0,
         "sumW": 108269000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 101254000.0,
         "sumW": 101254104.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 134496000.0,
         "sumW": 134496000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 55477000.0,
         "sumW": 55477000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 33767000.0,
         "sumW": 33767000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 17726000.0,
         "sumW": 17726000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 6125000.0,
         "sumW": 6125000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 3261000.0,
         "sumW": 3261000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 39772000.0,
         "sumW": 39772000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 40767000.0,
         "sumW": 40767000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 37307000.0,
         "sumW": 37307000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 75573000.0,
         "sumW": 75578936.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 57954000.0,
         "sumW": 57954552.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 56307000.0,
         "sumW": 56307000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 108269000.0,
         "sumW": 108269000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 101254000.0,
         "sumW": 101254104.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 134496000.0,
         "sumW": 134496000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 55477000.0,
         "sumW": 55477000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 33767000.0,
         "sumW": 33767000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 17726000.0,
         "sumW": 17726000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 6125000.0,
         "sumW": 6125000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 3261000.0,
         "sumW": 3261000.0
     },
-    "QCD_PT.*\{
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 39772000.0,
         "sumW": 39772000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 40767000.0,
         "sumW": 40767000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 37307000.0,
         "sumW": 37307000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 75573000.0,
         "sumW": 75578936.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 57954000.0,
         "sumW": 57954552.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 56307000.0,
         "sumW": 56307000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 108269000.0,
         "sumW": 108269000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 101254000.0,
         "sumW": 101254104.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 134496000.0,
         "sumW": 134496000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 55477000.0,
         "sumW": 55477000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 33767000.0,
         "sumW": 33767000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 17726000.0,
         "sumW": 17726000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 6125000.0,
         "sumW": 6125000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 3261000.0,
         "sumW": 3261000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_Pt_15to30": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 39772000.0,
         "sumW": 39772000.0
     },
-    "QCD_Pt_30to50": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 40767000.0,
         "sumW": 40767000.0
     },
-    "QCD_Pt_50to80": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 37307000.0,
         "sumW": 37307000.0
     },
-    "QCD_Pt_80to120": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 75573000.0,
         "sumW": 75578936.0
     },
-    "QCD_Pt_120to170": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 57954000.0,
         "sumW": 57954552.0
     },
-    "QCD_Pt_170to300": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 56307000.0,
         "sumW": 56307000.0
     },
-    "QCD_Pt_300to470": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 108269000.0,
         "sumW": 108269000.0
     },
-    "QCD_Pt_470to600": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 101254000.0,
         "sumW": 101254104.0
     },
-    "QCD_Pt_600to800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 134496000.0,
         "sumW": 134496000.0
     },
-    "QCD_Pt_800to1000": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 55477000.0,
         "sumW": 55477000.0
     },
-    "QCD_Pt_1000to1400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 33767000.0,
         "sumW": 33767000.0
     },
-    "QCD_Pt_1400to1800": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 17726000.0,
         "sumW": 17726000.0
     },
-    "QCD_Pt_1800to2400": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 6125000.0,
         "sumW": 6125000.0
     },
-    "QCD_Pt_2400to3200": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 3261000.0,
         "sumW": 3261000.0
     },
-    "QCD_Pt_3200toInf": {
+    "QCD_PT.*\{
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
+++ b/data/Run3_v12_Run2_v9/2018/Sample/CommonSampleInfo.json
@@ -224,7 +224,7 @@
         "sumsign": 19902000.0,
         "sumW": 19902000.0
     },
-    "QCD_PT_15to30": {
+    "QCD_Pt_15to30": {
         "isMC": 1,
         "PD": "QCD_Pt_15to30_TuneCP5_13TeV_pythia8",
         "xsec": 1245000000,
@@ -232,7 +232,7 @@
         "sumsign": 39772000.0,
         "sumW": 39772000.0
     },
-    "QCD_PT_30to50": {
+    "QCD_Pt_30to50": {
         "isMC": 1,
         "PD": "QCD_Pt_30to50_TuneCP5_13TeV_pythia8",
         "xsec": 106900000,
@@ -240,7 +240,7 @@
         "sumsign": 40767000.0,
         "sumW": 40767000.0
     },
-    "QCD_PT_50to80": {
+    "QCD_Pt_50to80": {
         "isMC": 1,
         "PD": "QCD_Pt_50to80_TuneCP5_13TeV_pythia8",
         "xsec": 15700000,
@@ -248,7 +248,7 @@
         "sumsign": 37307000.0,
         "sumW": 37307000.0
     },
-    "QCD_PT_80to120": {
+    "QCD_Pt_80to120": {
         "isMC": 1,
         "PD": "QCD_Pt_80to120_TuneCP5_13TeV_pythia8",
         "xsec": 2339000,
@@ -256,7 +256,7 @@
         "sumsign": 75573000.0,
         "sumW": 75578936.0
     },
-    "QCD_PT_120to170": {
+    "QCD_Pt_120to170": {
         "isMC": 1,
         "PD": "QCD_Pt_120to170_TuneCP5_13TeV_pythia8",
         "xsec": 407700,
@@ -264,7 +264,7 @@
         "sumsign": 57954000.0,
         "sumW": 57954552.0
     },
-    "QCD_PT_170to300": {
+    "QCD_Pt_170to300": {
         "isMC": 1,
         "PD": "QCD_Pt_170to300_TuneCP5_13TeV_pythia8",
         "xsec": 103600,
@@ -272,7 +272,7 @@
         "sumsign": 56307000.0,
         "sumW": 56307000.0
     },
-    "QCD_PT_300to470": {
+    "QCD_Pt_300to470": {
         "isMC": 1,
         "PD": "QCD_Pt_300to470_TuneCP5_13TeV_pythia8",
         "xsec": 6831,
@@ -280,7 +280,7 @@
         "sumsign": 108269000.0,
         "sumW": 108269000.0
     },
-    "QCD_PT_470to600": {
+    "QCD_Pt_470to600": {
         "isMC": 1,
         "PD": "QCD_Pt_470to600_TuneCP5_13TeV_pythia8",
         "xsec": 552.2,
@@ -288,7 +288,7 @@
         "sumsign": 101254000.0,
         "sumW": 101254104.0
     },
-    "QCD_PT_600to800": {
+    "QCD_Pt_600to800": {
         "isMC": 1,
         "PD": "QCD_Pt_600to800_TuneCP5_13TeV_pythia8",
         "xsec": 156.5,
@@ -296,7 +296,7 @@
         "sumsign": 134496000.0,
         "sumW": 134496000.0
     },
-    "QCD_PT_800to1000": {
+    "QCD_Pt_800to1000": {
         "isMC": 1,
         "PD": "QCD_Pt_800to1000_TuneCP5_13TeV_pythia8",
         "xsec": 26.27,
@@ -304,7 +304,7 @@
         "sumsign": 55477000.0,
         "sumW": 55477000.0
     },
-    "QCD_PT_1000to1400": {
+    "QCD_Pt_1000to1400": {
         "isMC": 1,
         "PD": "QCD_Pt_1000to1400_TuneCP5_13TeV_pythia8",
         "xsec": 7.478,
@@ -312,7 +312,7 @@
         "sumsign": 33767000.0,
         "sumW": 33767000.0
     },
-    "QCD_PT_1400to1800": {
+    "QCD_Pt_1400to1800": {
         "isMC": 1,
         "PD": "QCD_Pt_1400to1800_TuneCP5_13TeV_pythia8",
         "xsec": 0.6486,
@@ -320,7 +320,7 @@
         "sumsign": 17726000.0,
         "sumW": 17726000.0
     },
-    "QCD_PT_1800to2400": {
+    "QCD_Pt_1800to2400": {
         "isMC": 1,
         "PD": "QCD_Pt_1800to2400_TuneCP5_13TeV_pythia8",
         "xsec": 0.08745,
@@ -328,7 +328,7 @@
         "sumsign": 6125000.0,
         "sumW": 6125000.0
     },
-    "QCD_PT_2400to3200": {
+    "QCD_Pt_2400to3200": {
         "isMC": 1,
         "PD": "QCD_Pt_2400to3200_TuneCP5_13TeV_pythia8",
         "xsec": 0.005235,
@@ -336,7 +336,7 @@
         "sumsign": 3261000.0,
         "sumW": 3261000.0
     },
-    "QCD_PT_3200toInf": {
+    "QCD_Pt_3200toInf": {
         "isMC": 1,
         "PD": "QCD_Pt_3200toInf_TuneCP5_13TeV_pythia8",
         "xsec": 0.0001352,

--- a/data/Run3_v12_Run2_v9/MakeTaggingEffJson.py
+++ b/data/Run3_v12_Run2_v9/MakeTaggingEffJson.py
@@ -1,151 +1,276 @@
-#to run this script, you need to install uproot.
 import ROOT
 import correctionlib.convert as convert
 import json
 import argparse
 import os
-import itertools
+import concurrent.futures
+from tqdm import tqdm
 
-def histParser(f):
-    numerator_dicts = []
-    denominator_dicts = []
-    for keyObj in f.GetListOfKeys():
+# ---------------------------------------------------------------------
+# 1. Parse histogram keys from a ROOT file
+# ---------------------------------------------------------------------
+def histParser(root_file):
+    """
+    Parse all histogram keys in the given ROOT file.
+    Expected key format (example):
+      tagging#b##era#2022EE##tagger#deepJet##working_point#M##flavor#5##systematic#central##num
+      or for the denominator:
+      tagging#b##era#2022EE##flavor#5##systematic#central##den
+    Returns a list of dictionaries with extracted fields and the full key.
+    """
+    hist_list = []
+    for keyObj in root_file.GetListOfKeys():
         key = keyObj.GetName()
-        if not '##' in key:
+        if "##" not in key:
             continue
-        infos = key.split("##")
-        this_info = {}
-        isNumerator = True
-        for info in infos:
-            if 'den' in info:
-                isNumerator = False
+        segments = key.split("##")
+        info = {}
+        # Process each segment: if it contains '#' then split into field and value.
+        for seg in segments:
+            if '#' not in seg:
+                # Fallback: sometimes the type might be appended at the end.
+                info["hist_type"] = seg.strip()
                 continue
-            if 'num' in info:
-                isNumerator = True
+            parts = seg.split("#", 1)
+            if len(parts) < 2:
                 continue
-            k, value = info.split("#")
-            this_info[k] = value
-        this_info['hist_key']=key
-        if isNumerator:
-            numerator_dicts.append(this_info)
-        else:
-            denominator_dicts.append(this_info)
-    return numerator_dicts, denominator_dicts
-        
-def makeTempEffHist(f):
-    numerator_dicts, denominator_dicts = histParser(f)
-    ratio_hists = []
-    for numerator_dict in numerator_dicts:
-        #find denominator that have same flavor, tagging
-        for denominator_dict in denominator_dicts:
-            if numerator_dict['flavor'] == denominator_dict['flavor']:
-                numerator_hist = f.Get(numerator_dict['hist_key'])
-                denominator_hist = f.Get(denominator_dict['hist_key'])
-                ratio_hist = numerator_hist.Clone()
-                ratio_hist.Divide(denominator_hist)
-                print(f"{numerator_dict['hist_key']} divided by {denominator_dict['hist_key']}")
-                ratio_hist.SetName(numerator_dict['hist_key'].replace("num","eff"))
-                ratio_hists.append(ratio_hist)
+            field, value = parts
+            info[field] = value
+        # Try to set hist_type if not set: look at the key ending.
+        if "hist_type" not in info:
+            if key.endswith("num"):
+                info["hist_type"] = "num"
+            elif key.endswith("den"):
+                info["hist_type"] = "den"
+            elif key.endswith("eff"):
+                info["hist_type"] = "eff"
+        info["hist_key"] = key
+        hist_list.append(info)
+    return hist_list
 
-    f2 = ROOT.TFile("output.root","RECREATE")
-    f2.cd()
-    for ratio_hist in ratio_hists:
-        ratio_hist.Write()
-    f2.Close()
-
-def makingJson(era, f, taggingmode):
-    categorys={
-    "systematic":{"type":"string","content":["central"]},
-    "working_point":{ "type":"string","content":["L","M","T","XT","XXT"],"description":"L/M/T/XT/XXT"},
-    "flavor":{"type":"int","content":[4,5,0],"description":"hadron flavor definition: 5=b, 4=c, 0=udsg"},
-    }
-    if taggingmode == 'c':
-        categorys['working_point']['content'] = ["L","M","T"]
-        categorys['working_point']['description'] = "L/M/T"
-
-    main_json = {"schema_version": 2,
-               "description": "This json file contains the corrections for the deepJet, particleNet, robustParticleTransformer AK4 jet taggers for the 2022_Summer22 campaign.  Corrections are supplied for b-tag discriminator shape correction (shape) and b-tagging working point corrections (comb/mujets/light)",
-             "corrections": []}
+# ---------------------------------------------------------------------
+# 2. Create efficiency histograms by matching numerator and denominator histograms
+# ---------------------------------------------------------------------
+def makeTempEffHist(in_file):
+    """
+    From the input ROOT file (in_file), find matching numerator and denominator histograms.
     
-    taggers = ["deepJet","particleNet","robustParticleTransformer"]
+    Note that the numerator histogram key contains extra fields (tagger and working_point)
+    while the denominator is shared among taggers/working points. We match based on:
+    
+      - tagging
+      - era
+      - flavor
+      - systematic
+    
+    For each numerator histogram, the corresponding denominator is the one whose key
+    matches these fields and has hist_type "den".
+    
+    The resulting efficiency histogram (with key "eff") is saved to "output.root".
+    """
+    hist_list = histParser(in_file)
+    
+    # Separate numerator and denominator histograms
+    num_list = [h for h in hist_list if h.get("hist_type", "") == "num"]
+    den_list = [h for h in hist_list if h.get("hist_type", "") == "den"]
 
-    #loop that make basic struture of json. (categorys)
-    for tagger in taggers:
-        tagger_eff_dict={}
-        tagger_eff_dict['name'] = tagger
-        tagger_eff_dict['version'] = 0
-        tagger_eff_dict['inputs'] = []
-        for name, cat in categorys.items():
-            if 'description' in cat:
-                tagger_eff_dict['inputs'].append({"name":name,"type":cat['type'],"description":cat['description']})
-            else:
-                tagger_eff_dict['inputs'].append({"name":name,"type":cat['type']})
-        tagger_eff_dict['inputs'].append({"name":'abseta',"type":"real"})
-        tagger_eff_dict['inputs'].append({"name":'pt',"type":"real"})
-        tagger_eff_dict['output'] = {"name":"eff","type":"real"}
-        data_dict = {"nodetype":"category","input":"systematic","content":[]}
-        tagger_eff_dict['data']=data_dict
-        for systematic in categorys['systematic']['content']:
-            data_dict['content'].append({"key":systematic,"value":{'nodetype':"category","input":"working_point","content":[]}})
-            for working_point in categorys['working_point']['content']:
-                data_dict['content'][-1]['value']['content'].append({"key":working_point,"value":{'nodetype':"category","input":"flavor","content":[]}})
-                for flavor in categorys['flavor']['content']:
-                    data_dict['content'][-1]['value']['content'][-1]['value']['content'].append({"key":flavor,"value":{}})
-
-        main_json['corrections'].append(tagger_eff_dict)
-
-    #below part is responsible for actual value
-
-
-    for tagger, systematic, working_point, flavor in itertools.product(taggers,categorys['systematic']['content'],categorys['working_point']['content'],categorys['flavor']['content']):
-        c1 = convert.from_uproot_THx(f'output.root:tagging#{taggingmode}##era#{era}##tagger#{tagger}##working_point#{working_point}##flavor#{flavor}##systematic#{systematic}##eff;1')
-        this_data = c1.dict()['data']
-        this_data['inputs'] = ['abseta','pt']
-        this_data['flow'] = 'clamp'
-        #now find the appropriate location in main_json put this data
-        for tagger_dict in main_json['corrections']:
-            if tagger_dict['name'] == tagger:
-                for systematic_dict in tagger_dict['data']['content']:
-                    if systematic_dict['key'] == systematic:
-                        for working_point_dict in systematic_dict['value']['content']:
-                            if working_point_dict['key'] == working_point:
-                                for flavor_dict in working_point_dict['value']['content']:
-                                    if flavor_dict['key'] == flavor:
-                                        
-                                        flavor_dict['value'] = this_data
-                                        break
-                                break
-                        break
+    eff_hists = []
+    # Matching criteria for numerator vs. denominator:
+    # Only match on these fields: tagging, era, flavor, systematic.
+    match_fields = ["tagging", "era", "flavor", "systematic"]
+    for num_info in num_list:
+        # For each numerator, try to find a denominator that matches on the common fields.
+        matching_den = None
+        for den_info in den_list:
+            print(f"Will find denominator for numerator: {[num_info[f] for f in match_fields]}")
+            print("Total list of denominator: ")
+            for den in den_list:
+                print(f"Denominator: {[den[f] for f in match_fields]}")
+            if all(num_info.get(f) == den_info.get(f) for f in match_fields):
+                matching_den = den_info
                 break
-    
+        if not matching_den:
+            # If no matching denominator is found, skip this numerator.
+            print(f"WARNING: No denominator found for numerator: {num_info['hist_key']}")
+            continue
+
+        num_hist = in_file.Get(num_info["hist_key"])
+        den_hist = in_file.Get(matching_den["hist_key"])
+        if not num_hist or not den_hist:
+            print(f"WARNING: Missing histogram object for {num_info['hist_key']} or {matching_den['hist_key']}")
+            continue
+
+        # Create efficiency histogram by cloning numerator and dividing by denominator.
+        eff_name = num_info["hist_key"].replace("num", "eff")
+        eff_hist = num_hist.Clone(eff_name)
+        eff_hist.Divide(den_hist)
+        eff_hists.append(eff_hist)
+        print(f"Created efficiency histogram: {eff_name}")
+
+    # Write all efficiency histograms to a new ROOT file "output.root"
+    out_file = ROOT.TFile("output.root", "RECREATE")
+    out_file.cd()
+    for hist in eff_hists:
+        hist.Write()
+    out_file.Close()
+
+# ---------------------------------------------------------------------
+# 3. Worker function to convert an efficiency histogram to correction data
+# ---------------------------------------------------------------------
+def process_histogram(hist_info):
+    """
+    Reopen the "output.root" file and convert the efficiency histogram given by hist_info.
+    Returns a tuple: (tagger, systematic, working_point, flavor, conversion_data)
+    """
+    hist_path = f"output.root:{hist_info['hist_key']}"
+    try:
+        conv = convert.from_uproot_THx(hist_path)
+        conv_data = conv.dict()['data']
+        # Adjust conversion dictionary as in your original Code 2.
+        conv_data['inputs'] = ['abseta', 'pt']
+        conv_data['flow'] = 'clamp'
+    except Exception as e:
+        raise RuntimeError(f"Conversion failed for {hist_info['hist_key']}: {e}")
+
+    # For grouping, extract tagger, working_point, and flavor.
+    # (For the denominator these fields are missing, but we only process efficiency histograms,
+    #  which come from numerators and thus include tagger and working_point.)
+    tagger = hist_info.get("tagger")
+    systematic = hist_info.get("systematic")
+    working_point = hist_info.get("working_point")
+    try:
+        flavor = int(hist_info.get("flavor"))
+    except (TypeError, ValueError):
+        flavor = None
+
+    return (tagger, systematic, working_point, flavor, conv_data)
+
+# ---------------------------------------------------------------------
+# 4. Build the JSON corrections file dynamically
+# ---------------------------------------------------------------------
+def makingJson(era, tagging_mode):
+    """
+    Open the merged efficiency ROOT file ("output.root"), parse its histogram keys,
+    filter for a given era and tagging mode ("b" or "c"), convert each histogram in parallel,
+    and group the results into a nested JSON structure.
+    """
+    out_file = ROOT.TFile("output.root", "READ")
+    hist_list = histParser(out_file)
+    out_file.Close()
+
+    # Filter for efficiency histograms matching the era and tagging mode.
+    filtered = [h for h in hist_list 
+                if h.get("hist_type", "") == "eff" and
+                   h.get("era") == era and
+                   h.get("tagging") == tagging_mode]
+
+    conversion_results = []
+    with concurrent.futures.ProcessPoolExecutor() as executor:
+        futures = [executor.submit(process_histogram, h) for h in filtered]
+        for future in tqdm(concurrent.futures.as_completed(futures),
+                           total=len(futures),
+                           desc="Converting histograms"):
+            try:
+                conversion_results.append(future.result())
+            except Exception as e:
+                print(f"Error converting histogram: {e}")
+
+    # Group the conversion results by tagger → systematic → working_point → flavor.
+    grouped = {}
+    for tagger, systematic, wp, flavor, data in conversion_results:
+        if None in (tagger, systematic, wp, flavor):
+            continue
+        grouped.setdefault(tagger, {}).setdefault(systematic, {}).setdefault(wp, {})[flavor] = data
+
+    corrections = []
+    for tagger, syst_dict in grouped.items():
+        corr_entry = {
+            "name": tagger,
+            "version": 0,
+            "inputs": [
+                {"name": "systematic", "type": "string"},
+                {"name": "working_point", "type": "string", "description": "b-tagging working point"},
+                {"name": "flavor", "type": "int", "description": "hadron flavor definition: 5=b, 4=c, 0=udsg"},
+                {"name": "abseta", "type": "real"},
+                {"name": "pt", "type": "real"}
+            ],
+            "output": {"name": "eff", "type": "real"},
+            "data": {
+                "nodetype": "category",
+                "input": "systematic",
+                "content": []
+            }
+        }
+        for systematic, wp_dict in syst_dict.items():
+            syst_entry = {
+                "key": systematic,
+                "value": {
+                    "nodetype": "category",
+                    "input": "working_point",
+                    "content": []
+                }
+            }
+            for wp, flav_dict in wp_dict.items():
+                wp_entry = {
+                    "key": wp,
+                    "value": {
+                        "nodetype": "category",
+                        "input": "flavor",
+                        "content": []
+                    }
+                }
+                for flav, data in flav_dict.items():
+                    wp_entry["value"]["content"].append({"key": flav, "value": data})
+                wp_entry["value"]["content"].sort(key=lambda x: x["key"])
+                syst_entry["value"]["content"].append(wp_entry)
+            syst_entry["value"]["content"].sort(key=lambda x: x["key"])
+            corr_entry["data"]["content"].append(syst_entry)
+        corr_entry["data"]["content"].sort(key=lambda x: x["key"])
+        corrections.append(corr_entry)
+
+    main_json = {
+        "schema_version": 2,
+        "description": "This json file contains the b-tagging efficiency corrections",
+        "corrections": corrections
+    }
     return main_json
 
+# ---------------------------------------------------------------------
+# 5. Main script: process the input file and write JSON files
+# ---------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(
+        description="Create b-tagging efficiency JSON file dynamically")
+    parser.add_argument('--input_folder', dest='input_folder',
+                        help="Folder containing ROOT files",
+                        default=os.path.join(os.environ.get('SKNANO_OUTPUT', ''), 'MeasureJetTaggingEff'))
+    parser.add_argument('--input', dest='input',
+                        help="Input ROOT file name", default='TTLJ_powheg.root')
+    parser.add_argument('--out_name_str', dest='out_name_str',
+                        help="Output JSON file name prefix", default='')
+    args = parser.parse_args()
 
+    # List of eras to process (adjust as needed)
+    totalEras = ['2017']
+    for era in totalEras:
+        out_dir = os.path.join(os.environ.get('SKNANO_DATA', ''), era, 'BTV')
+        os.makedirs(out_dir, exist_ok=True)
+        input_path = os.path.join(args.input_folder, era, args.input)
+        in_file = ROOT.TFile(input_path)
+        if not in_file or in_file.IsZombie():
+            raise RuntimeError(f"Cannot open file: {input_path}")
 
+        # Create efficiency histograms by matching numerator and denominator histograms.
+        makeTempEffHist(in_file)
+        in_file.Close()
+
+        # Process both tagging modes: "b" and "c"
+        for tagging_mode, json_suffix in zip(["b", "c"], ["btaggingEff.json", "ctaggingEff.json"]):
+            main_json = makingJson(era, tagging_mode)
+            out_path = os.path.join(out_dir, args.out_name_str + json_suffix)
+            with open(out_path, "w") as fout:
+                json.dump(main_json, fout, indent=4)
+            print(f"Wrote JSON file: {out_path}")
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description='Create JSON file for b-tagging efficiency')
-    parser.add_argument('--input_folder', dest='input_folder',help='Input ROOT file folder',default=os.environ['SKNANO_OUTPUT']+'/MeasureJetTaggingEff')
-    parser.add_argument('--input',dest='input', help='Input ROOT file name', default='TTLJ_powheg.root')
-    parser.add_argument('--out_name_str',dest='out_name_str', help='Output JSON file name', default='')
-    args = parser.parse_args()
-    out_name_str = args.out_name_str
-
-    totalEras = ['2022','2022EE']
-    for era in totalEras:
-        out_dir = os.path.join(os.environ['SKNANO_DATA'],era,'BTV')
-        if not os.path.exists(out_dir):
-            os.makedirs(out_dir)
-        
-        f = ROOT.TFile(os.path.join(args.input_folder, era, args.input))
-        makeTempEffHist(f)
-        main_json_btagging = makingJson(era, f, 'b')
-        main_json_ctagging = makingJson(era, f, 'c')
-        with open(os.path.join(out_dir,out_name_str+'btaggingEff.json'), 'w') as f:
-            json.dump(main_json_btagging, f, indent=4)
-        with open(os.path.join(out_dir,out_name_str+'ctaggingEff.json'), 'w') as f:
-            json.dump(main_json_ctagging, f, indent=4)
-
-
-
-
+    main()


### PR DESCRIPTION
# summary

1. Fix typo for keys in 2023
2. Some electron SF now depends on $\phi$. I add $\phi$ as input. When evaluating SF from correctionlib, check number of input and determine give $\phi$ as input or not.
3. nPSWeight==1 is Pythia sample. check nPSWeight and now ISR and FSR variation return 1.f in case of nPSWeight==1.
4. renaming in function on Systematichelper
5. renaming PD, QCD_Pt to QCD_PT for RunII datasets.
6. check MeasureJetTaggingEff is work and update the json-making script for this
7. WP XT(Very tight) and XXY(very very tight) only exist for Run-3 b-tagging. In other cases, GetC(B)TaggingWP returns 1 as wp value.