### PR TITLE
RoccoR build template fetch & fix build error from SystematicHelper

### DIFF
--- a/Analyzers/src/DiLepton.cc
+++ b/Analyzers/src/DiLepton.cc
@@ -15,9 +15,9 @@ void DiLepton::initializeAnalyzer() {
     // Initialize SystematicHelper
     string SKNANO_HOME = getenv("SKNANO_HOME");
     if (IsDATA) {
-        systHelper = std::make_unique<SystematicHelper>(SKNANO_HOME + "/AnalyzerTools/noSyst.yaml", DataStream);
+        systHelper = std::make_unique<SystematicHelper>(SKNANO_HOME + "/AnalyzerTools/noSyst.yaml", DataStream, DataEra);
     } else {
-        systHelper = std::make_unique<SystematicHelper>(SKNANO_HOME + "/AnalyzerTools/DiLeptonSystematic.yaml", MCSample);
+        systHelper = std::make_unique<SystematicHelper>(SKNANO_HOME + "/AnalyzerTools/DiLeptonSystematic.yaml", MCSample, DataEra);
     }
 
     // Setup weight function map for SystematicHelper

--- a/setup.sh
+++ b/setup.sh
@@ -170,6 +170,27 @@ echo "@@@@ Correction lib: $CORRECTION_LIB_DIR"
 # ROCCOR
 export ROCCOR_PATH=$SKNANO_HOME/external/RoccoR
 
+# Check and copy RoccoR template files if missing
+if [[ ! -f "$ROCCOR_PATH/CMakeLists.txt" ]] || [[ ! -f "$ROCCOR_PATH/RoccoR_LinkDef.hpp" ]]; then
+    echo -e "\033[32m@@@@ Missing RoccoR build files, copying from templates...\033[0m"
+    if [[ ! -f "$ROCCOR_PATH/CMakeLists.txt" ]]; then
+        if [[ -f "$SKNANO_HOME/templates/RoccoR/CMakeLists.txt" ]]; then
+            cp "$SKNANO_HOME/templates/RoccoR/CMakeLists.txt" "$ROCCOR_PATH/"
+            echo "@@@@ Copied CMakeLists.txt to external/RoccoR/"
+        else
+            echo -e "\033[31m@@@@ Template CMakeLists.txt not found in templates/RoccoR/\033[0m"
+        fi
+    fi
+    if [[ ! -f "$ROCCOR_PATH/RoccoR_LinkDef.hpp" ]]; then
+        if [[ -f "$SKNANO_HOME/templates/RoccoR/RoccoR_LinkDef.hpp" ]]; then
+            cp "$SKNANO_HOME/templates/RoccoR/RoccoR_LinkDef.hpp" "$ROCCOR_PATH/RoccoR_LinkDef.hpp"
+            echo "@@@@ Copied RoccoR_LinkDef.hpp to external/RoccoR/RoccoR_LinkDef.hpp"
+        else
+            echo -e "\033[31m@@@@ Template RoccoR_LinkDef.hpp not found in templates/RoccoR/\033[0m"
+        fi
+    fi
+fi
+
 # JSONPOG integration auto-update
 check_jsonpog_updates() {
     local auto_update=${1:-false}

--- a/templates/RoccoR/CMakeLists.txt
+++ b/templates/RoccoR/CMakeLists.txt
@@ -1,0 +1,27 @@
+set(HEADERS RoccoR.h)
+set(SOURCES RoccoR.cc)
+add_library(RoccoR SHARED
+    ${SOURCES}
+)
+
+target_include_directories(RoccoR PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${ROOT_INCLUDE_DIRS}>
+    $<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(RoccoR ${ROOT_LIBRARIES})
+
+ROOT_GENERATE_DICTIONARY(G__RoccoR
+    ${HEADERS}
+    MODULE RoccoR
+    LINKDEF RoccoR_LinkDef.hpp
+)
+
+install(TARGETS RoccoR DESTINATION lib)
+
+set(ROOTMAP "libRoccoR.rootmap")
+set(PCM "libRoccoR_rdict.pcm")
+message(STATUS "ROOTMAP: ${ROOTMAP}")
+message(STATUS "PCM: ${PCM}")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${ROOTMAP} ${CMAKE_CURRENT_BINARY_DIR}/${PCM} DESTINATION lib)

--- a/templates/RoccoR/RoccoR_LinkDef.hpp
+++ b/templates/RoccoR/RoccoR_LinkDef.hpp
@@ -1,0 +1,10 @@
+#ifdef __CINT__
+
+#pragma link off all globals;
+#pragma link off all classes;
+#pragma link off all functions;
+#pragma link C++ nestedclasses;
+
+#pragma link C++ class RoccoR+;
+
+#endif


### PR DESCRIPTION
Predifined CMakeLists.txt in templates/RoccoR and fetch automatically if missing in submodules.